### PR TITLE
fix wav length inconsistency

### DIFF
--- a/src/miipher/preprocess/noiseAugmentation.py
+++ b/src/miipher/preprocess/noiseAugmentation.py
@@ -95,9 +95,12 @@ class DegrationApplier:
             noise = noise.repeat(1, waveform.size(1) // noise.size(1) + 1)[
                 :, : waveform.size(1)
             ]
-        augmented = torchaudio.functional.add_noise(
-            waveform=waveform, noise=noise, snr=torch.tensor([snr])
-        )
+        if noise.abs().max() > 0:
+            augmented = torchaudio.functional.add_noise(
+                waveform=waveform, noise=noise, snr=torch.tensor([snr])
+            )
+        else:
+            augmented = waveform
         return augmented
 
     def process(self, waveform, sample_rate):


### PR DESCRIPTION
Thank you for sharing these codes as open-source. It is quite helpful for me to understand how a miipher-like speech enhancement model can be implemented.
Through experiments, I found that noise augmentation used in preprocessing, especially mp3 encoding and reverberation effects, add some extra samples to the original waveform.
So I added a tiny fix to ensure the waveform length be identical before and after the augmentation.
If it seems fine, could you merge this PR? Thanks in advance.